### PR TITLE
Upgrade pinenacl to 0.6.0 to Resolve Dart SDK 3.5.0 Compatibility Issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   fixnum: ^1.1.0
-  pinenacl: ^0.5.1
+  pinenacl: ^0.6.0
   pointycastle: ^3.7.3
 
 dev_dependencies:


### PR DESCRIPTION
Upgraded the pinenacl dependency. Dart 3.5.0 has a breaking change that deprecates the `UnmodifiableUint8ListView` class. This was pushed to the stable version of flutter earlier this month.

It works fine with just this change for me.